### PR TITLE
run auton first, then this inversion of left and right works.

### DIFF
--- a/src/main/java/frc/robot/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/CommandSwerveDrivetrain.java
@@ -57,8 +57,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
             this::seedFieldRelative,  // Consumer for seeding pose against auto
             this::getCurrentRobotChassisSpeeds,
             (speeds)->this.setControl(autoRequest.withSpeeds(speeds)), // Consumer of ChassisSpeeds to drive the robot
-            new HolonomicPathFollowerConfig(new PIDConstants(80, 0, 0),
-                                            new PIDConstants(10, 0, 0),
+            new HolonomicPathFollowerConfig(new PIDConstants(1, 0, 0),
+                                            new PIDConstants(1, 0, 0),
                                             TunerConstants.kSpeedAt12VoltsMps,
                                             driveBaseRadius,
                                             new ReplanningConfig()),

--- a/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/src/main/java/frc/robot/generated/TunerConstants.java
@@ -53,8 +53,8 @@ public class TunerConstants {
     private static final double kWheelRadiusInches = 2;
 
     private static final boolean kSteerMotorReversed = false; //false
-    private static final boolean kInvertLeftSide = true; //false
-    private static final boolean kInvertRightSide = false; //true
+    private static final boolean kInvertLeftSide = false;  //true; //false
+    private static final boolean kInvertRightSide = true;  //false; //true
 
     private static final String kCANbusName = "DRIVEbus";
     private static final int kPigeonId = 50;


### PR DESCRIPTION
Teleop works after auton, too.

But run teleop first, then forward/backwards okay, but left/right are backwards


We will go with this change for now.  Just means we need to run auton (i.e. Practice) and some auton.
We can make a do nothing auton to be clear and make it the default.
