### PR TITLE
Logging now goes to Rio instead of USB stick; tweak C-2-3-M3 (Playoff), 3 angle

### DIFF
--- a/src/main/deploy/pathplanner/paths/BCenter - Source Note.path
+++ b/src/main/deploy/pathplanner/paths/BCenter - Source Note.path
@@ -73,7 +73,7 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": -32.0,
+    "rotation": -29.0,
     "rotateFast": false
   },
   "reversed": false,

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -49,13 +49,14 @@ public class Robot extends LoggedRobot {
 
     // Set up data receivers
     // Running on a real robot, log to a USB stick ("/U/logs")
-    Logger.addDataReceiver(new WPILOGWriter());
+    Logger.addDataReceiver(new WPILOGWriter("/home/lvuser/logs"));
     Logger.addDataReceiver(new NT4Publisher());
 
     // See http://bit.ly/3YIzFZ6 for more information on timestamps in AdvantageKit.
     // Logger.disableDeterministicTimestamps()
 
-    SignalLogger.setPath("//media/sda1/");
+    // media/sda1 is a usb stick
+    // SignalLogger.setPath(//media/sda1/);
     // SignalLogger.start();
     
     // Start AdvantageKit logger


### PR DESCRIPTION
To allow for use of USB-to-Ethernet adapter as workaround fix for robot being disabled during matches at MARC , make these changes to still log data to Rio instead of USB stick.

This branch also has a tweak to  C-2-3-M3 (Playoff) to the 3 heading.  It was shooting too far right of the speaker at MARC.  This change is untested and based solely off the video of elimination match.